### PR TITLE
tools: victim: fix timeout count with pre-decrement

### DIFF
--- a/tools/victim/victim.c
+++ b/tools/victim/victim.c
@@ -323,7 +323,7 @@ int main(int argc, char **argv)
 			return 1;
 		}
 		memset(trigger_buf, 0, sizeof(trigger_buf));
-		while (count--) {
+		while (--count) {
 			if ((fd = open(trigger, O_RDONLY)) < 0) {
 				sleep(1);
 				continue;


### PR DESCRIPTION
The post-decrement of count in while loop will end with count equal to -1, result in failing to catch triggering timeout.

Change to use pre-decrement.

Signed-off-by: Shuai Xue <xueshuai@linux.alibaba.com>