### PR TITLE
ltp-pan: fix wait_handler declaration

### DIFF
--- a/tools/ltp-pan/zoolib.h
+++ b/tools/ltp-pan/zoolib.h
@@ -49,7 +49,7 @@ extern char zoo_error[ZELEN];
 int lock_file( FILE *fp, short ltype, char **errmsg );
 /* FILE *open_file( char *file, char *mode, char **errmsg ); */
 
-void wait_handler();
+void wait_handler(int sig);
 
 /*  char *zoo_active( void ); */
 /* zoo_getname(): create a filename to use for the zoo


### PR DESCRIPTION
to match definition in:
tools/ltp-pan/ltp-pan.c:wait_handler( int sig )

* fixes build with gcc-15:

ltp-pan.c: In function 'main':
ltp-pan.c:459:19: error: assignment to '__sighandler_t' {aka 'void (*)(int)'} from incompatible pointer type 'void (*)(void)' [-Wincompatible-pointer-types]
  459 |     sa.sa_handler = wait_handler;
      |                   ^
In file included from ltp-pan.c:67:
zoolib.h:52:6: note: 'wait_handler' declared here
   52 | void wait_handler();
      |      ^~~~~~~~~~~~
In file included from TOPDIR/tmp/work/core2-64-oe-linux/mce-test/20230601+git/recipe-sysroot/usr/include/sys/param.h:28,
                 from ltp-pan.c:56:
TOPDIR/tmp/work/core2-64-oe-linux/mce-test/20230601+git/recipe-sysroot/usr/include/signal.h:72:16: note: '__sighandler_t' declared here
   72 | typedef void (*__sighandler_t) (int);
      |                ^~~~~~~~~~~~~~
ltp-pan.c:489:17: error: too many arguments to function 'wait_handler'; expected 0, have 1
  489 |                 wait_handler(SIGINT);
      |                 ^~~~~~~~~~~~ ~~~~~~